### PR TITLE
install: add explicit sudo and virtualenv tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ before_install:
  - echo 'en_US.UTF-8 UTF-8' | sudo tee /var/lib/locales/supported.d/local
 install:
   - pip install ansible==1.9.0.1
+  - ansible-galaxy install -r requirements.yml --force
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check
-  - ansible-playbook -i inventory test.yml --connection=local --sudo
+  - ansible-playbook -i inventory test.yml --connection=local -e '@test_vars.yml'
   - >
-    ansible-playbook -i inventory test.yml --connection=local --sudo
+    ansible-playbook -i inventory test.yml --connection=local -e '@test_vars.yml'
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/README.md
+++ b/README.md
@@ -13,22 +13,68 @@ Ansible role for installing a Python 3.x version from source.
 
 #### Role Dependencies
 
-- [ANXS.build-essential](https://github.com/ANXS/build-essential)
 - [alliedplatform.security](https://github.com/alliedplatform/security-ansible-role)
 
 #### Variables
 
-##### Python version options
+##### Required variables
 
-- `python_version` - the Python version to be installed.
+- `python_major_minor_version` - the Python version which includes the major and minor levels (MAJOR.MINOR), but does **not** contain the patch level. This variable will be used to identify the specific Python binary to be executed in commands.
+- `python_major_minor_patch_version` - the Python version which includes the major, minor and patch levels (MAJOR.MINOR.PATCH). This will be the version used to determine the Python source package to retrieve and build. The major and minor levels for this variable **must** be the same as in the `python_major_minor_version` variable described above.
 - `python_compressed_source_md5sum` - the md5sum for the XZ-compressed Python source. This is used to verify the integrity of the file after it is downloaded.
+- `python_virtualenvs` - a list of YAML dictionaries describing the Python virtual environments that will be created and the pip requirements manifest that specifies what Python packages to install in each. This variable will only be effective if the `python_virtualenv_install` variable is set to `yes`.
 
-##### Python build options
+Example:
+
+```
+python_virtualenvs:
+  - name: virtualenv1
+    requirements: /app/someapp1/requirements.txt
+  - name: virtualenv2
+    requirements: /app/someapp2/requirements.txt
+```
+
+##### Optional variables
 
 - `python_configuration_dir` - the absolute directory to hold the build flags manifest for the Python installation. This directory will hold a `.python_compilation_flags` manifest which, in turn, contains the Python version that was build along with the build flags used. The `.python_compilation_flags` manifest is used by Ansible to check if any changes are needed to the host on subsequent playbook runs. By default, this is set to `/etc/python`.
 - `python_compressed_source_path` - the absolute destination path for the XZ-compressed Python source when downloaded to the host. The compressed Python source will be deleted after it is extracted. By default, this is set to `/var/tmp/python.tar.xz`.
 - `python_source_dir` - the absolute uncompressed Python source directory (build directory). By default, this is set to `/usr/src/python`.
-- `python_source_default_configure_flags` - the build flags to use during the makefile generation. By default, only the `--enable-shared` is provided to configure script.
+- `python_source_default_configure_flags` - the build flags to use during the makefile generation.
+- `python_install_prefix_dir` - the absolute directory to where the Python `bin`, `include`, `lib` and `share` directories and files will be installed after the build.
+- `python_binaries_dir` - the absolute directory to the Python `bin` directory.
+- `python_libraries_dir` - the absolute directory to the Python `lib` directory.
+- `python_exec_path` - the absolute path to the Python interpreter binary that was installed after the build process.
+- `python_pip_exec_path` - the absolute path to the `pip` executable.
+- `python_virtualenv_exec_path` - the absolute path to the `virtualenv` executable.
+- `python_source_default_configure_flags` - the configure flags used when generating the makefile for building Python.
+- `python_user` - the user who owns the Python installation and the contents of the Python virtual environments. The default setting is `python-data`.
+- `python_group` - the user group to which the `python_user` belongs. The default setting is `python-data`.
+- `python_virtualenv_install` - determines if Python virtual environments are to be installed. The default setting is `yes`.
+- `python_virtualenv_home_dir` - the absolute directory to where the Python virtual environments will be created.
+
+#### Testing
+
+##### Local tests
+
+A Vagrantfile has been included with this project to provision a virtual machine with the Ansible role using some test data. Due to the fact that this role has hard dependencies on other roles, the typical `vagrant up` command cannot be run directly. Instead, a `test.sh` Bash script is provided at the root of this repository to gather the required Ansible roles from the Ansible Galaxy service and then provision the Vagrant virtual machine. Please execute the following steps to use the `test.sh` script:
+
+1. Provide the `test.sh` script with execute permissions.
+
+```
+$ chmod +x test.sh
+```
+
+2. Run the `test.sh` script.
+
+```
+$ ./test.sh
+```
+
+To destroy the Vagrant virtual machine after the provisioning process is complete, execute `vagrant destroy` and follow the prompts.
+
+##### Automated tests
+
+Automated tests to check the correctness of the Ansible playbook syntax and the idempotency of the role are executed after a commit to GitHub. These automated tests are performed by [Travis CI](https://travis-ci.org/).
 
 #### Notes
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,8 @@ Vagrant.configure('2') do |config|
     c.vm.hostname = 'ap.local'
     c.vm.provision 'ansible' do |ansible|
       ansible.playbook = 'test.yml'
-      ansible.sudo = true
+      ansible.verbose = 'vv'
+      ansible.extra_vars = 'test_vars.yml'
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
     end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+
+roles_path =  ~/ansible/roles

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,19 @@
 ---
 
-python_version: 3.4.3
-python_compressed_source_md5sum: 7d092d1bba6e17f0d9bd21b49e441dd5
-
-python_configuration_dir: "/etc/python"
+python_configuration_dir: "/home/{{ python_user }}/etc/python"
 python_compressed_source_path: "/var/tmp/python.tar.xz"
-python_source_dir: "/usr/src/python"
-python_source_default_configure_flags: "--enable-shared"
+python_source_dir: "/home/{{ python_user }}/src/python"
+python_install_prefix_dir: "/home/{{ python_user }}/local"
+python_binaries_dir: "{{ python_install_prefix_dir }}/bin"
+python_libraries_dir: "{{ python_install_prefix_dir }}/lib"
+python_exec_path: "{{ python_binaries_dir }}/python{{ python_major_minor_version }}"
+python_pip_exec_path: "{{ python_binaries_dir }}/pip{{ python_major_minor_version }}"
+python_virtualenv_exec_path: "{{ python_binaries_dir }}/virtualenv"
+
+python_source_default_configure_flags: "--enable-shared --prefix={{ python_install_prefix_dir }}"
+
+python_user: "python-data"
+python_group: "python-data"
+
+python_virtualenv_install: yes
+python_virtualenv_home_dir: "/home/{{ python_user }}/venv"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,5 +15,4 @@ galaxy_info:
   - development
 
 dependencies:
-  - ANXS.build-essential
   - alliedplatform.security

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+
+- src: alliedplatform.security

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,28 +4,72 @@
   include: install/Ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
+- name: Create the operating system-level group to interact with Python
+  group:
+    name: "{{ python_group }}"
+    state: present
+  sudo: yes
+  register: python_os_group
+
+- name: Create the operating system-level user to interact with Python
+  user:
+    name: "{{ python_user }}"
+    group: "{{ python_group }}"
+    shell: /bin/false
+    state: present
+    system: yes
+  sudo: yes
+  register: python_os_user
+
+- name: Set the appropriate expiration on the dedicated user for Python interaction
+  command: "sudo chage -I -1 -E -1 -m -1 -M -1 -W -1 -E -1 {{ python_user }}"
+  when: python_os_group.changed or python_os_user.changed
+
+- name: Create the Python configuration directory
+  file:
+    path: "{{ python_configuration_dir }}"
+    state: directory
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+
+- name: Set the directory permissions for the Python configuration directory
+  file:
+    path: "{{ python_configuration_dir }}"
+    owner: "{{ python_user }}"
+    group: "{{ python_group }}"
+    mode: 0755
+    state: directory
+
 - name: Write out the Python version and the flags used for the build
   template:
     src: .python_compilation_flags.j2
     dest: "{{ python_configuration_dir }}/.python_compilation_flags"
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   register: python_build_flags
 
 - name: Creates Python source directory
   file:
     path: "{{ python_source_dir }}"
     state: directory
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
 - name: Download the XZ-compressed Python source
   get_url:
-    url: "https://www.python.org/ftp/python/{{ python_version }}/Python-{{ python_version }}.tar.xz"
+    url: "https://www.python.org/ftp/python/{{ python_major_minor_patch_version }}/Python-{{ python_major_minor_patch_version }}.tar.xz"
     dest: "{{ python_compressed_source_path }}"
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
 - name: Compute the md5sum of the compressed Python source
   stat:
     path: "{{ python_compressed_source_path }}"
     get_md5: yes
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   register: p
   when: python_build_flags.changed
 
@@ -38,12 +82,9 @@
   shell: >
     tar -xJC {{ python_source_dir }} --strip-components=1 -f {{ python_compressed_source_path }} &&
     rm {{ python_compressed_source_path }}
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
-
-- name: Remove compressed Python source
-  file:
-    path: "{{ python_compressed_source_path }}"
-    state: absent
 
 - name: Configure makefile, compile and install Python binaries
   shell: >
@@ -51,15 +92,52 @@
     ./configure {{ python_source_default_configure_flags }} &&
     make -j$(nproc) &&
     make altinstall
+  sudo: yes
+  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
-- name: Update system shared libraries to include new Python libraries
-  command: ldconfig
-  args:
-    chdir: "{{ python_source_dir }}"
-  when: python_build_flags.changed
-
-- name: Remove uncompressed Python source
+- name: Remove uncompressed Python source and build artifacts
   file:
     path: "{{ python_source_dir }}"
     state: absent
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+
+- name: Update system shared libraries to include new Python libraries
+  shell: >
+    ldconfig "{{ python_libraries_dir }}"
+  sudo: yes
+  when: python_build_flags.changed
+
+- name: Bootstrap the pip installer
+  shell: >
+    "{{ python_exec_path }}" -m ensurepip --altinstall
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+  when: python_build_flags.changed
+
+- name: Ensure pip is at the latest version
+  shell: >
+    "{{ python_pip_exec_path }}" install pip --upgrade
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+  when: python_virtualenv_install
+
+- name: Install virtualenv via pip
+  pip:
+    name: virtualenv
+    executable: "{{ python_pip_exec_path }}"
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+  when: python_virtualenv_install
+
+- name: Create and populate the specified Python virtual environments
+  pip:
+    requirements: "{{ item.requirements }}"
+    virtualenv: "{{ python_virtualenv_home_dir }}/{{ item.name }}"
+    virtualenv_command: "{{ python_virtualenv_exec_path }}"
+    executable: "{{ python_pip_exec_path }}"
+  sudo: yes
+  sudo_user: "{{ python_user }}"
+  with_items: python_virtualenvs
+  when: python_virtualenv_install and python_virtualenvs|length > 0

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -6,8 +6,16 @@
     update_cache: yes
     force: yes
     state: installed
+  sudo: yes
 
 - name: Ensure that the UTF-8 locale is present and set
   locale_gen:
     name: en_US.UTF-8
     state: present
+
+- name: Remove any current Python packages via APT
+  apt:
+    name: python3*
+    force: yes
+    state: absent
+  sudo: yes

--- a/templates/.python_compilation_flags.j2
+++ b/templates/.python_compilation_flags.j2
@@ -1,2 +1,2 @@
-{{python_version}}
+{{python_major_minor_patch_version}}
 {{python_source_default_configure_flags}}

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ansible-galaxy install -r requirements.yml --force
+vagrant up

--- a/test.yml
+++ b/test.yml
@@ -1,4 +1,6 @@
 - hosts: all
+  roles:
+    - alliedplatform.security
   vars_files:
     - 'defaults/main.yml'
   tasks:

--- a/test_vars.yml
+++ b/test_vars.yml
@@ -1,0 +1,6 @@
+---
+
+python_major_minor_version: '3.4'
+python_major_minor_patch_version: '3.4.3'
+python_compressed_source_md5sum: '7d092d1bba6e17f0d9bd21b49e441dd5'
+python_virtualenvs: []


### PR DESCRIPTION
Add explicit sudo instructions on plays which
require them, add non-root user for owning
the Python artifacts and virtual environments,
remove 'ansible.sudo=yes` from Vagrantfile and
add tasks for installing and managing the
Python virtual environments.

Fixes #2, Fixes #3