### PR TITLE
all: add change conditional to md5sum hash verification task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - echo localhost > inventory
   - ansible-playbook -i inventory test.yml --syntax-check
-  - ansible-playbook -i inventory test.yml --connection=local -e '@test_vars.yml'
+  - ansible-playbook -i inventory test.yml --connection=local -e '@test_vars.yml' -vv
   - >
     ansible-playbook -i inventory test.yml --connection=local -e '@test_vars.yml'
     | grep -q 'changed=0.*failed=0'

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 
+host_key_checking = False
 roles_path =  ~/ansible/roles

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -70,13 +70,13 @@
     get_md5: yes
   sudo: yes
   sudo_user: "{{ python_user }}"
-  register: p
+  register: python_source_verification
   when: python_build_flags.changed
 
 - name: Verify the md5sum of the compressed Python source
   fail:
     msg: "The md5sum of the compressed Python source does not match the expected value"
-  when: p.stat.md5 != "{{ python_compressed_source_md5sum }}"
+  when: python_source_verification is defined and python_source_verification.stat.md5 != "{{ python_compressed_source_md5sum }}"
 
 - name: Unpack the Python source and remove the compressed Python source
   shell: >
@@ -121,6 +121,8 @@
     "{{ python_pip_exec_path }}" install pip --upgrade
   sudo: yes
   sudo_user: "{{ python_user }}"
+  register: pip_upgrade_output
+  changed_when: '"""${pip_upgrade_output.stdout}""".find("Requirement already up-to-date") != -1'
   when: python_virtualenv_install
 
 - name: Install virtualenv via pip

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 
+# Retrieve and install any required Ansible roles from Ansible Galaxy.
 ansible-galaxy install -r requirements.yml --force
+
+# Provision the Vagrant machine with Ansible.
 vagrant up
+
+# Rerun the same Ansible playbook to check for idempotency.
+ansible-playbook test.yml -i vagrant-inventory \
+  -u vagrant --private-key=.vagrant/machines/ap/virtualbox/private_key \
+  -e '@test_vars.yml' -vv


### PR DESCRIPTION
Add change conditional to md5sum verification task
to ensure that the md5sum is not computed against
the compressed Python source that is not present.
Add idempotency test to the 'test.sh' script.

Fixes #5, Fixes #6