### PR TITLE
install: change directory structure for Python artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ python_virtualenvs:
 ##### Optional variables
 
 - `python_configuration_dir` - the absolute directory to hold the build flags manifest for the Python installation. This directory will hold a `.python_compilation_flags` manifest which, in turn, contains the Python version that was build along with the build flags used. The `.python_compilation_flags` manifest is used by Ansible to check if any changes are needed to the host on subsequent playbook runs. By default, this is set to `/etc/python`.
-- `python_compressed_source_path` - the absolute destination path for the XZ-compressed Python source when downloaded to the host. The compressed Python source will be deleted after it is extracted. By default, this is set to `/var/tmp/python.tar.xz`.
-- `python_source_dir` - the absolute uncompressed Python source directory (build directory). By default, this is set to `/usr/src/python`.
+- `python_compressed_source_path` - the absolute destination path for the XZ-compressed Python source when downloaded to the host. The compressed Python source will be deleted after it is extracted. By default, this is set to `/tmp/python.tar.xz`.
+- `python_source_dir` - the absolute uncompressed Python source directory (build directory). By default, this is set to `/src/python`.
 - `python_source_default_configure_flags` - the build flags to use during the makefile generation.
-- `python_install_prefix_dir` - the absolute directory to where the Python `bin`, `include`, `lib` and `share` directories and files will be installed after the build.
+- `python_install_prefix_dir` - the absolute directory to where the Python `bin`, `include`, `lib` and `share` directories and files will be installed after the build. By default, this is set to `/opt/python`.
 - `python_binaries_dir` - the absolute directory to the Python `bin` directory.
 - `python_libraries_dir` - the absolute directory to the Python `lib` directory.
 - `python_exec_path` - the absolute path to the Python interpreter binary that was installed after the build process.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 
-python_configuration_dir: "/home/{{ python_user }}/etc/python"
-python_compressed_source_path: "/var/tmp/python.tar.xz"
-python_source_dir: "/home/{{ python_user }}/src/python"
-python_install_prefix_dir: "/home/{{ python_user }}/local"
+python_configuration_dir: "/etc/python"
+python_compressed_source_path: "/tmp/python.tar.xz"
+python_source_dir: "/src/python"
+python_install_prefix_dir: "/opt/python"
 python_binaries_dir: "{{ python_install_prefix_dir }}/bin"
 python_libraries_dir: "{{ python_install_prefix_dir }}/lib"
 python_exec_path: "{{ python_binaries_dir }}/python{{ python_major_minor_version }}"
@@ -16,4 +16,6 @@ python_user: "python-data"
 python_group: "python-data"
 
 python_virtualenv_install: yes
-python_virtualenv_home_dir: "/home/{{ python_user }}/venv"
+python_virtualenv_home_dir: "{{ python_configuration_dir }}/virtual-envs"
+
+python_source_url: "https://www.python.org/ftp/python/{{ python_major_minor_patch_version }}/Python-{{ python_major_minor_patch_version }}.tar.xz"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,9 +28,10 @@
 - name: Create the Python configuration directory
   file:
     path: "{{ python_configuration_dir }}"
+    owner: "{{ python_user }}"
+    group: "{{ python_group }}"
     state: directory
   sudo: yes
-  sudo_user: "{{ python_user }}"
 
 - name: Set the directory permissions for the Python configuration directory
   file:
@@ -39,6 +40,7 @@
     group: "{{ python_group }}"
     mode: 0755
     state: directory
+  sudo: yes
 
 - name: Write out the Python version and the flags used for the build
   template:
@@ -53,15 +55,13 @@
     path: "{{ python_source_dir }}"
     state: directory
   sudo: yes
-  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
 - name: Download the XZ-compressed Python source
   get_url:
-    url: "https://www.python.org/ftp/python/{{ python_major_minor_patch_version }}/Python-{{ python_major_minor_patch_version }}.tar.xz"
+    url: "{{ python_source_url }}"
     dest: "{{ python_compressed_source_path }}"
   sudo: yes
-  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
 - name: Compute the md5sum of the compressed Python source
@@ -69,7 +69,6 @@
     path: "{{ python_compressed_source_path }}"
     get_md5: yes
   sudo: yes
-  sudo_user: "{{ python_user }}"
   register: python_source_verification
   when: python_build_flags.changed
 
@@ -83,7 +82,6 @@
     tar -xJC {{ python_source_dir }} --strip-components=1 -f {{ python_compressed_source_path }} &&
     rm {{ python_compressed_source_path }}
   sudo: yes
-  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
 
 - name: Configure makefile, compile and install Python binaries
@@ -93,15 +91,22 @@
     make -j$(nproc) &&
     make altinstall
   sudo: yes
-  sudo_user: "{{ python_user }}"
   when: python_build_flags.changed
+
+- name: Update ownership on the Python install directory and its contents
+  file:
+    path: "{{ python_install_prefix_dir }}"
+    owner: "{{ python_user }}"
+    group: "{{ python_group }}"
+    recurse: yes
+    state: directory
+  sudo: yes
 
 - name: Remove uncompressed Python source and build artifacts
   file:
     path: "{{ python_source_dir }}"
     state: absent
   sudo: yes
-  sudo_user: "{{ python_user }}"
 
 - name: Update system shared libraries to include new Python libraries
   shell: >


### PR DESCRIPTION
Change directory structure for Python build
artifacts, source files, binaries, libraries,
and the Python virtual environments.

Fixes #9