### PR TITLE
install: add user tasks file to separate user management

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,29 +1,11 @@
 ---
 
-- name: Include Ubuntu-specific tasks
+- name: Include Ubuntu-specific installation tasks
   include: install/Ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- name: Create the operating system-level group to interact with Python
-  group:
-    name: "{{ python_group }}"
-    state: present
-  sudo: yes
-  register: python_os_group
-
-- name: Create the operating system-level user to interact with Python
-  user:
-    name: "{{ python_user }}"
-    group: "{{ python_group }}"
-    shell: /bin/false
-    state: present
-    system: yes
-  sudo: yes
-  register: python_os_user
-
-- name: Set the appropriate expiration on the dedicated user for Python interaction
-  command: "sudo chage -I -1 -E -1 -m -1 -M -1 -W -1 -E -1 {{ python_user }}"
-  when: python_os_group.changed or python_os_user.changed
+- name: Include Python user management tasks
+  include: user.yml
 
 - name: Create the Python configuration directory
   file:

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Create the operating system-level group to interact with Python
+  group:
+    name: "{{ python_group }}"
+    state: present
+  sudo: yes
+
+- name: Create the operating system-level user to interact with Python
+  user:
+    name: "{{ python_user }}"
+    group: "{{ python_group }}"
+    shell: /bin/false
+    state: present
+    system: yes
+  sudo: yes
+
+- name: Check the Python user current password expiry
+  command: grep {{ python_user }} /etc/shadow
+  sudo: yes
+  register: python_old_password
+  changed_when: false
+
+- name: Set the correct expiration on the Python user
+  shell: "chage -I -1 -E -1 -m -1 -M -1 -W -1 -E -1 {{ python_user }} && grep {{ python_user }} /etc/shadow"
+  sudo: yes
+  register: python_new_password
+  changed_when: python_new_password.stdout != python_old_password.stdout


### PR DESCRIPTION
Add 'user.yml' file (called from 'install.yml')
to separate the Python data user management tasks
from the remainder of the Python installation tasks.

Fixes #8