### PR TITLE
install: fix pip tasks around Python virtual environments

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -90,9 +90,17 @@
     state: absent
   sudo: yes
 
+- name: Insert Python shared libraries directory into ld.so.conf file
+  lineinfile:
+    dest: /etc/ld.so.conf
+    line: "{{ python_libraries_dir }}"
+    insertafter: EOF
+  sudo: yes
+  when: python_build_flags.changed
+  
 - name: Update system shared libraries to include new Python libraries
   shell: >
-    ldconfig "{{ python_libraries_dir }}"
+    ldconfig
   sudo: yes
   when: python_build_flags.changed
 
@@ -125,7 +133,7 @@
     requirements: "{{ item.requirements }}"
     virtualenv: "{{ python_virtualenv_home_dir }}/{{ item.name }}"
     virtualenv_command: "{{ python_virtualenv_exec_path }}"
-    executable: "{{ python_pip_exec_path }}"
+    executable: "{{ python_virtualenv_home_dir }}/{{ item.name }}/bin/pip{{ python_major_minor_version }}"
   sudo: yes
   sudo_user: "{{ python_user }}"
   with_items: python_virtualenvs


### PR DESCRIPTION
Add global Python shared libraries directory to ld.so.conf
after global Python installation and allow proper
Python virtual environment-specific pip binaries to
install packages into the Pythnon virtual environments.

Fixes #16