### PR TITLE
all: add 'alliedplatform.build-deps' dependency to role

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ansible role for installing a Python 3.x version from source.
 #### Role Dependencies
 
 - [alliedplatform.security](https://github.com/alliedplatform/security-ansible-role)
+- [alliedplatform.build-deps](https://github.com/alliedplatform/build-deps-ansible-role)
 
 #### Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,4 @@ galaxy_info:
 
 dependencies:
   - alliedplatform.security
+  - alliedplatform.build-deps

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 
 - src: alliedplatform.security
+- src: alliedplatform.build-deps

--- a/tasks/install/Ubuntu.yml
+++ b/tasks/install/Ubuntu.yml
@@ -1,13 +1,5 @@
 ---
 
-- name: Install autoconf package
-  apt:
-    name: autoconf
-    update_cache: yes
-    force: yes
-    state: installed
-  sudo: yes
-
 - name: Ensure that the UTF-8 locale is present and set
   locale_gen:
     name: en_US.UTF-8

--- a/test.yml
+++ b/test.yml
@@ -1,6 +1,7 @@
 - hosts: all
   roles:
     - alliedplatform.security
+    - alliedplatform.build-deps
   vars_files:
     - 'defaults/main.yml'
   tasks:


### PR DESCRIPTION
Add the 'alliedplatform.build-deps' dependency to the
role and remove all redundant tasks that are currently
part of the role which are also part of the
'alliedplatform.build-deps' role.

Fixes #19